### PR TITLE
Feature: Make callable

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,10 +1,10 @@
 [bumpversion]
-current_version = 0.0.0
+current_version = 1.0.0a1
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)
 	((?P<prerelease>[a-z]+)(?P<num>\d+))?
-serialize =
+serialize = 
 	{major}.{minor}.{patch}{prerelease}{num}
 	{major}.{minor}.{patch}
 commit = True
@@ -12,8 +12,8 @@ tag = True
 
 [bumpversion:part:prerelease]
 first_value = a
-values =
-    a
+values = 
+	a
 	b
 	rc
 
@@ -23,3 +23,4 @@ first_value = 1
 [bumpversion:file:README.md]
 
 [bumpversion:file:setup.py]
+

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -21,3 +21,5 @@ values =
 first_value = 1
 
 [bumpversion:file:README.md]
+
+[bumpversion:file:setup.py]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![CodeFactor](https://www.codefactor.io/repository/github/bastienboutonnet/sheetload/badge)](https://www.codefactor.io/repository/github/bastienboutonnet/sheetload)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 
-Package Version: `v0.0.0`
+Package Version: `v1.0.0a1`
 
 # sheetload
 A handy package to load Google Sheets to Snowflake

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,31 @@
+from setuptools import setup
+
+NAME = "sheetload"
+VERSION = "0.0.0"
+DESCRIPTION = """
+                sheetload is a command line tool to load sheets from google
+                and upload them to snowflake
+                """
+REQUIRED = [
+    # "git+ssh://git@github.com/tripactions/Data_Tooling.git@v1.8.7#egg=data-tools", # TODO:not sure how we can make that work
+    "pandas",
+    "pyyaml",
+    "snowflake==0.0.3",
+    "snowflake-ingest==0.9.1",
+    "snowflake-connector-python==1.7.4",
+    "tqdm",
+]
+REQUIRES_PYTHON = ">=3.6.0"
+
+
+setup(
+    name=NAME,
+    version=VERSION,
+    description=DESCRIPTION,
+    long_description=DESCRIPTION,
+    author="Bastien Boutonnet",
+    author_email="bastien.b1@gmail.com",
+    install_requires=REQUIRED,
+    python_requires=REQUIRES_PYTHON,
+    entry_points={"console_scripts": ["sheetload=sheetload.sheetload:run"]},
+)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 NAME = "sheetload"
-VERSION = "0.0.0"
+VERSION = "1.0.0a1"
 DESCRIPTION = """
                 sheetload is a command line tool to load sheets from google
                 and upload them to snowflake


### PR DESCRIPTION
## Description
Makes sheetload be callable from CLI like so: 
```bash
sheetload --sheet_key kshdaksjhdaki281i283 --schema sand --table bb_test_table
```

## How has this change been tested?
ran in dev env

## Supporting doc, tickets, issues (Optional)
Closes #6 
