### PR TITLE
Feature: Read config from yml file

### DIFF
--- a/sheetload/config.py
+++ b/sheetload/config.py
@@ -2,33 +2,17 @@ import os
 
 import yaml
 
-from sheetload.exceptions import SheetloadConfigMissingError
+from sheetload.exceptions import SheetloadConfigMissingError, SheetConfigParsingError
 from sheetload.flags import args, logger
 
 
 class FlagParser:
     def __init__(self):
-        self.fetch_yml_config = True
         self.sheet_name = args.sheet_name
         self.create_table = args.create_table
         self.sheet_key = args.sheet_key
         self.target_schema = args.schema
         self.target_table = args.table
-        if args.sheet_key and args.schema and args.table:
-            self.fetch_yml_config = False
-        if self.fetch_yml_config is True and not args.schema or not args.table:
-            raise NotImplementedError(
-                """
-                No target schema and or target was provided.
-                You must provide one when reading not from config."
-                """
-            )
-        if not args.sheet_key and not args.sheet_name:
-            raise NotImplementedError(
-                """
-                No sheet selected for import. Provide a sheet_key or a sheet_name.
-                See help, for hints."""
-            )
 
 
 class ConfigLoader(FlagParser):
@@ -37,43 +21,63 @@ class ConfigLoader(FlagParser):
         self.sheet_config = None
         self.sheet_columns = None
         FlagParser.__init__(self)
-        self.load_config_from_file()
+        self.set_config()
+
+    def set_config(self):
+        if self.sheet_name:
+            yml_exists = os.path.isfile("sheets.yml")
+            if yml_exists:
+                self.load_config_from_file()
+            else:
+                raise SheetloadConfigMissingError(
+                    "Are you in a sheetload folder? Cannot find 'sheets.yml' to import config from."
+                )
+        elif self.sheet_key and self.target_schema and self.target_table:
+            logger.info("Reading config from command line.")
+        else:
+            raise NotImplementedError(
+                """
+                No target schema and or target was provided.
+                You must provide one when not reading from config file.
+                """
+            )
 
     def load_config_from_file(self):
-        config_file_exists = os.path.isfile("sheets.yml")
-        if not self.fetch_yml_config:
-            logger.info("Reading config from command line arguments.")
-            pass
-        if config_file_exists and self.fetch_yml_config:
-            with open("sheets.yml", "r") as stream:
-                self.config = yaml.safe_load(stream)
+        logger.info("Reading config from command line arguments.")
+        with open("sheets.yml", "r") as stream:
+            self.config = yaml.safe_load(stream)
+        if self.config:
             self._get_sheet_config()
             self._generate_column_dict()
             self._override_cli_args()
-        elif not config_file_exists and self.fetch_yml_config:
-            raise SheetloadConfigMissingError(
-                "Are you in a sheetload folder? Cannot find 'sheets.yml' to import config from."
-            )
-
-    def _override_cli_args(self):
-        self.sheet_key = self.sheet_config["sheet_key"]
-        self.target_schema = self.sheet_config["schema"]
-        self.target_table = self.sheet_config["table"]
+        else:
+            raise SheetConfigParsingError("Your sheets.yml file seems empty.")
 
     def _get_sheet_config(self):
-        if self.fetch_yml_config:
+        if self.sheet_name:
             sheets = self.config["sheets"]
-            sheet_config = [sheet for sheet in sheets if sheet["sheet_name"] == "test_sheet"]
+            sheet_config = [sheet for sheet in sheets if sheet["sheet_name"] == self.sheet_name]
             if len(sheet_config) > 1:
-                raise AttributeError(
+                raise SheetConfigParsingError(
                     f"Found more than one config for {self.sheet_name}. Check your sheets.yml file."
                 )
+            elif not sheet_config:
+                raise SheetConfigParsingError(
+                    f"No configuration was found for {self.sheet_name}. Check your sheets.yml file."
+                )
             self.sheet_config = sheet_config[0]
+        else:
+            raise SheetloadConfigMissingError("No sheet name was provided, cannot fetch config.")
 
     def _generate_column_dict(self):
-        if self.fetch_yml_config and self.sheet_config:
+        if self.sheet_config:
             columns = self.sheet_config.get("columns")
             column_dict = dict()
             for column in columns:
                 column_dict.update(dict({column.get("name"): column.get("type")}))
             self.sheet_columns = column_dict
+
+    def _override_cli_args(self):
+        self.sheet_key = self.sheet_config["sheet_key"]
+        self.target_schema = self.sheet_config["schema"]
+        self.target_table = self.sheet_config["table"]

--- a/sheetload/config.py
+++ b/sheetload/config.py
@@ -1,30 +1,79 @@
+import os
+
 import yaml
 
+from sheetload.exceptions import SheetloadConfigMissingError
+from sheetload.flags import args, logger
 
-class ConfigLoader:
-    def __init__(self, sheet_name):
-        self.sheet_name = sheet_name
-        self.config = None
-        self.sheet_config = None
-        self.load_yml()
 
-    def load_yml(self):
-        with open("sheets.yml", "r") as stream:
-            self.config = yaml.safe_load(stream)
-
-    def get_sheet_config(self):
-        sheets = self.config["sheets"]
-        sheet_config = [sheet for sheet in sheets if sheet["sheet_name"] == "test_sheet"]
-        if len(sheet_config) > 1:
-            raise AttributeError(
-                f"Found more than one config for {self.sheet_name}. Check your sheets.yml file."
+class FlagParser:
+    def __init__(self):
+        self.fetch_yml_config = True
+        self.sheet_name = args.sheet_name
+        self.create_table = args.create_table
+        self.sheet_key = args.sheet_key
+        self.target_schema = args.schema
+        self.target_table = args.table
+        if args.sheet_key and args.schema and args.table:
+            self.fetch_yml_config = False
+        if self.fetch_yml_config is True and not args.schema or not args.table:
+            raise NotImplementedError(
+                """
+                No target schema and or target was provided.
+                You must provide one when reading not from config."
+                """
             )
-        self.sheet_config = sheet_config[0]
-        return self.sheet_config
+        if not args.sheet_key and not args.sheet_name:
+            raise NotImplementedError(
+                """
+                No sheet selected for import. Provide a sheet_key or a sheet_name.
+                See help, for hints."""
+            )
 
-    def generate_column_dict(self):
-        if self.sheet_config:
+
+class ConfigLoader(FlagParser):
+    def __init__(self):
+        self.config_file = None
+        self.sheet_config = None
+        self.sheet_columns = None
+        FlagParser.__init__(self)
+        self.load_config_from_file()
+
+    def load_config_from_file(self):
+        config_file_exists = os.path.isfile("sheets.yml")
+        if not self.fetch_yml_config:
+            logger.info("Reading config from command line arguments.")
+            pass
+        if config_file_exists and self.fetch_yml_config:
+            with open("sheets.yml", "r") as stream:
+                self.config = yaml.safe_load(stream)
+            self._get_sheet_config()
+            self._generate_column_dict()
+            self._override_cli_args()
+        elif not config_file_exists and self.fetch_yml_config:
+            raise SheetloadConfigMissingError(
+                "Are you in a sheetload folder? Cannot find 'sheets.yml' to import config from."
+            )
+
+    def _override_cli_args(self):
+        self.sheet_key = self.sheet_config["sheet_key"]
+        self.target_schema = self.sheet_config["schema"]
+        self.target_table = self.sheet_config["table"]
+
+    def _get_sheet_config(self):
+        if self.fetch_yml_config:
+            sheets = self.config["sheets"]
+            sheet_config = [sheet for sheet in sheets if sheet["sheet_name"] == "test_sheet"]
+            if len(sheet_config) > 1:
+                raise AttributeError(
+                    f"Found more than one config for {self.sheet_name}. Check your sheets.yml file."
+                )
+            self.sheet_config = sheet_config[0]
+
+    def _generate_column_dict(self):
+        if self.fetch_yml_config and self.sheet_config:
             columns = self.sheet_config.get("columns")
             column_dict = dict()
             for column in columns:
                 column_dict.update(dict({column.get("name"): column.get("type")}))
+            self.sheet_columns = column_dict

--- a/sheetload/config.py
+++ b/sheetload/config.py
@@ -1,0 +1,30 @@
+import yaml
+
+
+class ConfigLoader:
+    def __init__(self, sheet_name):
+        self.sheet_name = sheet_name
+        self.config = None
+        self.sheet_config = None
+        self.load_yml()
+
+    def load_yml(self):
+        with open("sheets.yml", "r") as stream:
+            self.config = yaml.safe_load(stream)
+
+    def get_sheet_config(self):
+        sheets = self.config["sheets"]
+        sheet_config = [sheet for sheet in sheets if sheet["sheet_name"] == "test_sheet"]
+        if len(sheet_config) > 1:
+            raise AttributeError(
+                f"Found more than one config for {self.sheet_name}. Check your sheets.yml file."
+            )
+        self.sheet_config = sheet_config[0]
+        return self.sheet_config
+
+    def generate_column_dict(self):
+        if self.sheet_config:
+            columns = self.sheet_config.get("columns")
+            column_dict = dict()
+            for column in columns:
+                column_dict.update(dict({column.get("name"): column.get("type")}))

--- a/sheetload/exceptions.py
+++ b/sheetload/exceptions.py
@@ -1,2 +1,16 @@
+# FIXME: There might be a better way to do that.
+# Ideally this class has a basic message which can be overridden.
+
+
 class SheetloadConfigMissingError(Exception):
-    pass
+    "When a sheet config cannot be found"
+
+
+class SheetConfigParsingError(Exception):
+    "For cases where sheet was found but content could not be parsed."
+
+
+# FIXME: There might also be a better way to do this. Check with Youri.
+external_errors_to_catch = {
+    "overwrite_cols_data_tools_error": "Looks like you have misspelled the name of at least one column in overwrite_defaults"
+}

--- a/sheetload/exceptions.py
+++ b/sheetload/exceptions.py
@@ -1,0 +1,2 @@
+class SheetloadConfigMissingError(Exception):
+    pass

--- a/sheetload/flags.py
+++ b/sheetload/flags.py
@@ -1,4 +1,7 @@
 import argparse
+import logging
+
+from data_tools.logging import LoggerFactory
 
 from sheetload._version import __version__
 
@@ -20,3 +23,13 @@ parser.add_argument(
 parser.add_argument("--dry_run", action="store_true", default=False)
 parser.add_argument("--i", action="store_true", default=False)
 args = parser.parse_args()
+
+
+# set up logger levels
+if args.log_level in {"debug", "warning", "info", "error"}:
+    logger = LoggerFactory.get_logger(level=getattr(logging, args.log_level.upper()))
+if args.mode == "dev":
+    args.log_level = "debug"
+    logger = LoggerFactory.get_logger(level=getattr(logging, "debug".upper()))
+else:
+    raise NotImplementedError("This level is not supported.")

--- a/sheetload/sheetload.py
+++ b/sheetload/sheetload.py
@@ -5,95 +5,29 @@ import pandas
 from data_tools.db import odbc
 from data_tools.db.pandas import push_pandas_to_snowflake
 from data_tools.google.sheets import Spreadsheet
-from data_tools.logging import LoggerFactory
 
-from sheetload.flags import args
-
-SHEET_NAME = None
-CREATE_TABLE = None
-TARGET_SCHEMA = None
-TARGET_TABLE = None
-
-# set up logger levels
-if args.log_level in {"debug", "warning", "info", "error"}:
-    logger = LoggerFactory.get_logger(level=getattr(logging, args.log_level.upper()))
-if args.mode == "dev":
-    args.log_level = "debug"
-    logger = LoggerFactory.get_logger(level=getattr(logging, "debug".upper()))
-else:
-    raise NotImplementedError("This level is not supported.")
+from sheetload.flags import args, logger
+from sheetload.config import ConfigLoader
 
 
-def set_flags_from_args(flags):
-    """SChecks arguments and sets flags
-
-    Args:
-        flags (argparse arguments): Arguments class from argparse
-    """
-
-    global SHEET_NAME, CREATE_TABLE, TARGET_SCHEMA, TARGET_TABLE
-    CREATE_TABLE = flags.create_table
-    if flags.sheet_key:
-        SHEET_NAME = flags.sheet_key
-        if not flags.schema or not flags.table:
-            raise NotImplementedError(
-                """
-                No target schema and or target was provided.
-                You must provide one when reading not from config."
-                """
-            )
-    if not flags.sheet_key and not flags.sheet_name:
-        raise NotImplementedError(
-            """
-            No sheet selected for import. Provide a sheet_key or a sheet_name.
-            See help, for hints."""
-        )
-
-
-class SheetBag:
+class SheetBag(ConfigLoader):
     def __init__(self):
-        self.sheet_name = SHEET_NAME
-        self.sheet_key = None
-        self.target_schema = None
-        self.target_table = None
-        self.create_table = False
+        ConfigLoader.__init__(self)
         self.sheet_df = None
-        self.parse_config()
+        self.consume_config()
 
-    def parse_config(self):
-        logger.info("Parsing configuration...")
-        self.target_schema = args.schema
+    def consume_config(self):
+        """Sets up overriding of config when needed.
+        """
+        logger.info("Reading configuration...")
 
-        # override target schema for dev.
+        # overrides target schema
         if args.mode == "dev" and not args.force:
             self.target_schema = "sand"
 
-        self.target_table = "bb_sheetload_test"
-        self.create_table = True
-
-        if SHEET_NAME:
-            self.sheet_key = SHEET_NAME
-        else:
-            self.sheet_key = "Unknown"
-        logger.info(self.sheet_key)
         logger.info(
             f"Running in {args.mode.upper()} mode."
             f"Log level: {args.log_level.upper()}. Writing to: {self.target_schema.upper()}"
-        )
-
-    @staticmethod
-    def check_answer(user_input):
-        acceptable_answers = ["y", "n", "a"]
-        if user_input in acceptable_answers:
-            if user_input.lower() == "y":
-                return True
-            if user_input.lower() == "n":
-                return False
-            if user_input.lower() == "a":
-                logger.info("User aborted.")
-                sys.exit(1)
-        raise NotImplementedError(
-            "Your response cannot be interpreted. Choose 'y':yes, 'n':no, 'a':abort"
         )
 
     def load_sheet(self):
@@ -112,14 +46,36 @@ class SheetBag:
         df = self.cleanup(df)
         self.sheet_df = df
 
+    @staticmethod
+    def _collect_and_check_answer():
+        acceptable_answers = ["y", "n", "a"]
+        user_input = None
+        while user_input not in acceptable_answers:
+            if user_input is not None:
+                logger.info(
+                    "Your response cannot be interpreted.Choose 'y':yes, 'n':no, 'a':abort'"
+                )
+            user_input = input("Would you like to perform cleanup? (y/n/a): ")
+        if user_input.lower() == "y":
+            return True
+        if user_input.lower() == "n":
+            return False
+        if user_input.lower() == "a":
+            logger.info("User aborted.")
+            sys.exit(1)
+
+    @staticmethod
+    def _show_dry_run_preview(sheet_df):
+        logger.info("\nDataFrame DataTypes: \n\n" + str(sheet_df.dtypes))
+        logger.info("\nDataFrame Preview: \n\n" + str(sheet_df.head(10)))
+
     def cleanup(self, df):
         clean_up = True
         # check for interactive mode
         if args.i:
             logger.info("PRE-CLEANING PREVIEW: This is what you would push to the database.")
             self._show_dry_run_preview(df)
-            clean_up_answer = input("Would you like to perform cleanup? (y/n/a): ")
-            clean_up = self.check_answer(clean_up_answer)
+            clean_up = self._collect_and_check_answer()
 
         if clean_up is True:
             logger.info("Housekeeping...")
@@ -135,15 +91,10 @@ class SheetBag:
                     df[col] = df[col].str.strip()
             clean_df = df
             if args.dry_run or args.i:
-                logger.info("This is what you would push to the database:")
-            self._show_dry_run_preview(clean_df)
+                logger.info("POST-CLEANING PREVIEW: This is what you would push to the database:")
+                self._show_dry_run_preview(clean_df)
 
             return clean_df
-
-    @staticmethod
-    def _show_dry_run_preview(sheet_df):
-        logger.info("\nDataFrame DataTypes: \n\n" + str(sheet_df.dtypes))
-        logger.info("\nDataFrame Preview: \n\n" + str(sheet_df.head(10)))
 
     def _check_table(self):
         columns_query = f"""
@@ -171,10 +122,11 @@ class SheetBag:
             except Exception as e:
                 raise RuntimeError(e)
             logger.info(f"Push successful. Columns {columns}, Rows: {rows}")
+        else:
+            logger.info("Nothing pushed since you were in --dry_run mode.")
 
 
 def run():
-    set_flags_from_args(args)
     sheetbag = SheetBag()
     sheetbag.load_sheet()
     sheetbag.push_sheet()

--- a/tests/sheets.yml
+++ b/tests/sheets.yml
@@ -1,0 +1,10 @@
+version: 2
+
+sheets:
+  - sheet_name: test_sheet
+    skeey_key: 10J52dhgTRqtI_lm4bf9B02nQu4zu5u6r0h2VIDTjRXg
+    columns:
+      - name: col_a
+        type: int
+      - name: col_b
+        type: object

--- a/tests/sheets.yml
+++ b/tests/sheets.yml
@@ -2,9 +2,11 @@ version: 2
 
 sheets:
   - sheet_name: test_sheet
-    skeey_key: 10J52dhgTRqtI_lm4bf9B02nQu4zu5u6r0h2VIDTjRXg
+    sheet_key: 10J52dhgTRqtI_lm4bf9B02nQu4zu5u6r0h2VIDTjRXg
+    schema: sand
+    table: bb_test_sheetload
     columns:
       - name: col_a
         type: int
       - name: col_b
-        type: object
+        type: varchar


### PR DESCRIPTION
## Description
Brings ability to read the config of a sheet from a yml file. This allows setting column data types correctly for example.
Usage:
From directory where `sheets.yml` file is present:
```bash
sheetload --sheet_name test_sheet
```
Other functionality is preserved (dry run and interactive)

## How has this change been tested?
manual tests for expected behaviour

## Supporting doc, tickets, issues (Optional)
Closes #1  and Fixes #18 

## Merge Instructions (Optional)
Part of the Jean-Michel Jarre release. To be merged in `dev/jean_michel_jarre`

## Checklist
(At least go through this list mentally or put an `x` between the brackets)
- [x] The PR is named correctly according to team standards.
- [x] My code follows the style guidelines (SQL style, black formatting, dbt design patterns)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have tested that my code works