### PR TITLE
Fix: Move yml validation in config parser

### DIFF
--- a/sheetload/config.py
+++ b/sheetload/config.py
@@ -4,7 +4,7 @@ import yaml
 
 from sheetload.exceptions import SheetloadConfigMissingError, SheetConfigParsingError
 from sheetload.flags import args, logger
-from sheetload.yaml_helpers import load_yaml
+from sheetload.yaml_helpers import load_yaml, validate_yaml
 
 
 class FlagParser:
@@ -20,7 +20,7 @@ class ConfigLoader(FlagParser):
     def __init__(self):
         self.config_file = None
         self.sheet_config = None
-        self.sheet_columns = None
+        self.sheet_columns = dict()
         FlagParser.__init__(self)
         self.set_config()
 
@@ -39,7 +39,9 @@ class ConfigLoader(FlagParser):
 
     def load_config_from_file(self):
         logger.info("Reading config from config file.")
-        self.config = load_yaml()
+        yml_is_valid = validate_yaml()
+        if yml_is_valid:
+            self.config = load_yaml()
         if self.config:
             self._get_sheet_config()
             self._generate_column_dict()
@@ -70,7 +72,8 @@ class ConfigLoader(FlagParser):
                 column_dict = dict()
                 for column in columns:
                     column_dict.update(dict({column["name"]: column["datatype"]}))
-                self.sheet_columns = column_dict
+                if column_dict:
+                    self.sheet_columns = column_dict
         except KeyError as e:
             logger.warning(
                 f"No {str(e)} data for {self.sheet_name}. But that might be intentional."

--- a/sheetload/sheetload.py
+++ b/sheetload/sheetload.py
@@ -117,7 +117,7 @@ class SheetBag(ConfigLoader):
     def push_sheet(self):
         if not args.dry_run:
             logger.info("Pushing sheet to Snowflake...")
-
+            logger.debug(f"Column override dict is a {type(self.sheet_columns)}")
             try:
                 push_pandas_to_snowflake(
                     self.sheet_df,
@@ -154,7 +154,6 @@ class SheetBag(ConfigLoader):
 
 
 def run():
-    validate_yaml()
     sheetbag = SheetBag()
     sheetbag.load_sheet()
     sheetbag.push_sheet()

--- a/sheetload/yaml_helpers.py
+++ b/sheetload/yaml_helpers.py
@@ -27,3 +27,4 @@ def validate_yaml():
     valid_yaml = v.validate(doc, validation_schema)
     if not valid_yaml:
         raise SheetConfigParsingError(f"scheet.yml is not formatted properly. \n {v.errors}")
+    return valid_yaml


### PR DESCRIPTION
## Description
This fixes the case where sheeloader will always try and find a sheet.yml to validate even if parsing from a key.