### PR TITLE
Refactor: Break complex class inheritances, Fix Argparse

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -20,10 +20,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r pip-requirements.txt -r dev-pip-requirements.txt
+    - name: Mypy checks
+      uses: jpetrucciani/mypy-check@master
+      with:
+        path: 'sheetload'
     - name: Test with pytest
       run: |
         cd tests/ && pytest
-    # - name: Mypy checks
-    #   uses: jpetrucciani/mypy-check@master
-    #   with:
-    #     path: 'sheetload'

--- a/dev-pip-requirements.txt
+++ b/dev-pip-requirements.txt
@@ -4,3 +4,4 @@ pytest-cov
 ipython
 mock
 mypy
+pytest-datafiles

--- a/dev-pip-requirements.txt
+++ b/dev-pip-requirements.txt
@@ -3,3 +3,4 @@ pytest
 pytest-cov
 ipython
 mock
+mypy

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,4 +1,4 @@
 cerberus
-data_tools @ git+ssh://git@github.com/tripactions/Data_Tooling.git@v2.0.0
+data_tools @ git+ssh://git@github.com/tripactions/Data_Tooling.git@v2.1.7
 pandas
 pyyaml

--- a/sheetload/config.py
+++ b/sheetload/config.py
@@ -1,15 +1,18 @@
+from typing import Type
+
 from sheetload.exceptions import SheetConfigParsingError, SheetloadConfigMissingError
 from sheetload.flags import FlagParser, logger
 from sheetload.yaml_helpers import load_yaml, validate_yaml
 
 
 class ConfigLoader:
-    def __init__(self, flags: FlagParser):
+    def __init__(self, flags: FlagParser, yml_folder: str = str()):
         self.config_file = None
         self.sheet_config: dict = dict()
         self.sheet_column_rename_dict: dict = dict()
         self.sheet_columns: dict = dict()
-        self.flags = FlagParser()
+        self.flags: FlagParser = flags
+        self.yml_folder: str = yml_folder
         self.set_config()
 
     def set_config(self):
@@ -27,9 +30,9 @@ class ConfigLoader:
 
     def load_config_from_file(self):
         logger.info("Reading config from config file.")
-        yml_is_valid = validate_yaml()
+        yml_is_valid = validate_yaml(self.yml_folder)
         if yml_is_valid:
-            self.config = load_yaml()
+            self.config = load_yaml(self.yml_folder)
         if self.config:
             self.get_sheet_config()
             self._generate_column_type_override_dict()

--- a/sheetload/config.py
+++ b/sheetload/config.py
@@ -1,33 +1,19 @@
-import collections
-
-from sheetload.exceptions import SheetloadConfigMissingError, SheetConfigParsingError
-from sheetload.flags import args, logger
+from sheetload.exceptions import SheetConfigParsingError, SheetloadConfigMissingError
+from sheetload.flags import FlagParser, logger
 from sheetload.yaml_helpers import load_yaml, validate_yaml
 
 
-class FlagParser:
-    def __init__(self, test=False):
-        if test:
-            self.sheet_name = "df_renamer"
-        else:
-            self.sheet_name = args.sheet_name
-        self.create_table = args.create_table
-        self.sheet_key = args.sheet_key
-        self.target_schema = args.schema
-        self.target_table = args.table
-
-
-class ConfigLoader(FlagParser):
-    def __init__(self, test=False):
+class ConfigLoader:
+    def __init__(self, flags: FlagParser):
         self.config_file = None
-        self.sheet_config = None
-        self.sheet_column_rename_dict = None
-        self.sheet_columns = dict()
-        FlagParser.__init__(self, test)
+        self.sheet_config: dict = dict()
+        self.sheet_column_rename_dict: dict = dict()
+        self.sheet_columns: dict = dict()
+        self.flags = FlagParser()
         self.set_config()
 
     def set_config(self):
-        if self.sheet_name:
+        if self.flags.sheet_name:
             self.load_config_from_file()
         elif self.sheet_key and self.target_schema and self.target_table:
             logger.info("Reading config from command line.")
@@ -47,7 +33,7 @@ class ConfigLoader(FlagParser):
         if self.config:
             self.get_sheet_config()
             self._generate_column_type_override_dict()
-            self.__generate_column_rename_dict()
+            self._generate_column_rename_dict()
             self._override_cli_args()
         else:
             raise SheetConfigParsingError("Your sheets.yml file seems empty.")
@@ -67,16 +53,18 @@ class ConfigLoader(FlagParser):
         return new
 
     def get_sheet_config(self):
-        if self.sheet_name:
+        if self.flags.sheet_name:
             sheets = self.config["sheets"]
-            sheet_config = [sheet for sheet in sheets if sheet["sheet_name"] == self.sheet_name]
+            sheet_config = [
+                sheet for sheet in sheets if sheet["sheet_name"] == self.flags.sheet_name
+            ]
             if len(sheet_config) > 1:
                 raise SheetConfigParsingError(
-                    f"Found more than one config for {self.sheet_name}. Check your sheets.yml file."
+                    f"Found more than one config for {self.flags.sheet_name}. Check your sheets.yml file."
                 )
             if not sheet_config:
                 raise SheetConfigParsingError(
-                    f"No configuration was found for {self.sheet_name}. Check your sheets.yml file."
+                    f"No configuration was found for {self.flags.sheet_name}. Check your sheets.yml file."
                 )
             self.sheet_config = sheet_config[0]
             logger.debug(f"Sheet config dict: {self.sheet_config}")
@@ -87,6 +75,10 @@ class ConfigLoader(FlagParser):
             raise SheetloadConfigMissingError("No sheet name was provided, cannot fetch config.")
 
     def _generate_column_type_override_dict(self):
+        """Generates a dictionary of key, value where key is the name of a column and value is the
+        name of the datatype into that column should be cast on table creation.
+        """
+
         try:
             if self.sheet_config:
                 columns = self.sheet_config["columns"]
@@ -98,10 +90,14 @@ class ConfigLoader(FlagParser):
                     self.sheet_columns = column_dict
         except KeyError as e:
             logger.warning(
-                f"No {str(e)} data for {self.sheet_name}. But that might be intentional."
+                f"No {str(e)} data for {self.flags.sheet_name}. But that might be intentional."
             )
 
-    def __generate_column_rename_dict(self):
+    def _generate_column_rename_dict(self):
+        """Generates a dictionary of key values where key is the original name in the sheet and
+        value is the target name.
+        """
+
         if self.sheet_config:
             columns = self.sheet_config.get("columns")
             if columns:
@@ -114,6 +110,10 @@ class ConfigLoader(FlagParser):
                         self.sheet_column_rename_dict = column_rename_dict
 
     def _override_cli_args(self):
+        """Overrides any CLI argument that may have been passed to sheeload when it reads from a
+        config yaml file, thereby giving precedence to the arguments in the .yml file.
+        """
+
         self.sheet_key = self.sheet_config["sheet_key"]
         self.target_schema = self.sheet_config["target_schema"]
         self.target_table = self.sheet_config["target_table"]

--- a/sheetload/flags.py
+++ b/sheetload/flags.py
@@ -8,7 +8,7 @@ from sheetload._version import __version__
 parser = argparse.ArgumentParser()
 parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
 parser.add_argument("--mode", help="Chooses between prod or dev run", type=str, default="dev")
-parser.add_argument("--log_level", help="sets the log level", type=str, default=None)
+parser.add_argument("--log_level", help="sets the log level", type=str, default=str())
 parser.add_argument("--sheet_name", help="Name of your sheet from config", type=str, default=None)
 parser.add_argument("--sheet_key", help="Google sheet Key", type=str, default=None)
 parser.add_argument("--schema", help="Target Schema Name", type=str, default=None)
@@ -29,7 +29,7 @@ parser.add_argument(
     "--dry_run", help="Skips pushing to database", action="store_true", default=False
 )
 parser.add_argument(
-    "--i",
+    "--interactive",
     help="Turns on interactive mode, which allows previews and cleanup choices",
     action="store_true",
     default=False,
@@ -37,24 +37,30 @@ parser.add_argument(
 
 
 class FlagParser:
-    def __init__(self, test=False):
-        if test:
-            self.sheet_name = "df_renamer"
-            self.create_table = False
-            self.sheet_key = parser.get_default("sheet_key")
-            self.target_schema = parser.get_default("schema")
-            self.target_table = parser.get_default("table")
-            self.mode = parser.get_default("mode")
-            self.log_level = parser.get_default("log_level")
-        else:
-            args = parser.parse_args()
-            self.sheet_name = args.sheet_name
-            self.create_table = args.create_table
-            self.sheet_key = args.sheet_key
-            self.target_schema = args.schema
-            self.target_table = args.table
-            self.mode = args.mode
-            self.log_level = args.log_level
+    def __init__(self):
+        self.sheet_name = "df_renamer"
+        self.create_table = False
+        self.sheet_key = parser.get_default("sheet_key")
+        self.target_schema = parser.get_default("schema")
+        self.target_table = parser.get_default("table")
+        self.mode = parser.get_default("mode")
+        self.log_level = parser.get_default("log_level")
+        self.force = parser.get_default("force")
+        self.interactive = parser.get_default("interactive")
+        self.dry_run = parser.get_default("dry_run")
+
+    def consume_cli_arguments(self):
+        args = parser.parse_args()
+        self.sheet_name = args.sheet_name
+        self.create_table = args.create_table
+        self.sheet_key = args.sheet_key
+        self.target_schema = args.schema
+        self.target_table = args.table
+        self.mode = args.mode
+        self.log_level = args.log_level
+        self.force = args.force
+        self.interactive = args.interactive
+        self.dry_run = args.dry_run
 
     def set_logger(self):
         if self.mode == "dev":

--- a/sheetload/sheetload.py
+++ b/sheetload/sheetload.py
@@ -10,7 +10,7 @@ from sheetload._version import __version__
 from sheetload.cleaner import SheetCleaner
 from sheetload.config import ConfigLoader
 from sheetload.exceptions import ColumnNotFoundInDataFrame, external_errors_to_catch
-from sheetload.flags import args, logger
+from sheetload.flags import FlagParser, logger
 
 
 class SheetBag(ConfigLoader):

--- a/sheetload/yaml_helpers.py
+++ b/sheetload/yaml_helpers.py
@@ -4,13 +4,19 @@ import yaml
 from cerberus import Validator
 
 from sheetload.exceptions import SheetConfigParsingError, SheetloadConfigMissingError
+from sheetload.flags import logger
 from sheetload.yaml_schema import validation_schema
 
 
-def load_yaml():
-    yml_exists = os.path.isfile("sheets.yml")
+def load_yaml(override_folder: str = str()) -> dict:
+    if override_folder:
+        yml_file = os.path.join(override_folder, "sheets.yml")
+    else:
+        yml_file = "sheets.yml"
+    yml_exists = os.path.isfile(yml_file)
+    logger.info(override_folder)
     if yml_exists:
-        with open("sheets.yml", "r") as stream:
+        with open(yml_file, "r") as stream:
             yaml_file = yaml.safe_load(stream)
             if yaml_file:
                 return yaml_file
@@ -21,9 +27,9 @@ def load_yaml():
         )
 
 
-def validate_yaml():
+def validate_yaml(override_folder: str = str()):
     v = Validator()
-    doc = load_yaml()
+    doc = load_yaml(override_folder)
     valid_yaml = v.validate(doc, validation_schema)
     if not valid_yaml:
         raise SheetConfigParsingError(f"scheet.yml is not formatted properly. \n {v.errors}")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,0 @@
-import sys
-
-sys.path.insert(0, "./")

--- a/tests/test_configloader.py
+++ b/tests/test_configloader.py
@@ -1,9 +1,19 @@
+import os
+
+import pytest
+
+from sheetload.flags import FlagParser
+
 from .mockers import EXPECTED_CONFIG
 
+FIXTURE_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)))
 
-def test_set_config():
+
+@pytest.mark.datafiles(FIXTURE_DIR)
+def test_set_config(datafiles):
     from sheetload.config import ConfigLoader
 
-    config = ConfigLoader(test=True)
+    flags = FlagParser()
+    config = ConfigLoader(flags, yml_folder=str(datafiles))
 
     assert config.sheet_config == EXPECTED_CONFIG

--- a/tests/test_sheetloader.py
+++ b/tests/test_sheetloader.py
@@ -1,23 +1,38 @@
-from .mockers import CLEAN_DF, RENAMED_COLS, DIRTY_DF, RENAMED_DF, generate_test_df
+import os
+
 import mock
+import pytest
+
+from sheetload.config import ConfigLoader
+from sheetload.flags import FlagParser
+
+from .mockers import DIRTY_DF, RENAMED_COLS, RENAMED_DF, generate_test_df
+
+FIXTURE_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)))
 
 
-def test_rename_columns():
+@pytest.mark.datafiles(FIXTURE_DIR)
+def test_rename_columns(datafiles):
     from sheetload.sheetload import SheetBag
 
+    flags = FlagParser()
+    config = ConfigLoader(flags, yml_folder=str(datafiles))
     df = generate_test_df(DIRTY_DF)
-    renamed_df = SheetBag(test=True).rename_columns(df)
+    renamed_df = SheetBag(config, flags).rename_columns(df)
 
     assert renamed_df.columns.tolist() == RENAMED_COLS
 
 
-def test_load_sheet():
+@pytest.mark.datafiles(FIXTURE_DIR)
+def test_load_sheet(datafiles):
     from sheetload.sheetload import SheetBag
 
+    flags = FlagParser()
+    config = ConfigLoader(flags, yml_folder=str(datafiles))
     with mock.patch.object(
         SheetBag, "_obtain_googlesheet", return_value=generate_test_df(DIRTY_DF)
     ):
-        sheetbag = SheetBag(test=True)
+        sheetbag = SheetBag(config, flags)
         sheetbag.load_sheet()
         target_df = generate_test_df(RENAMED_DF)
         assert target_df.equals(sheetbag.sheet_df)


### PR DESCRIPTION
## Description
This PR does a lot of under the hood action and solves badly written class inheritances by separating classes and passing them as arguments instead.
- It delays parsing of arguments until a proper run and sets default args for testing. Closes #48 
- Data tools requirements are now pinned higher to remove the warnings snowflake connector used to be throwing. Closes #64 

## How has this change been tested?
Tests are passing, run against the test sheet and creates the correct output.