### PR TITLE
Feature: Implement column dropping. Closes #50

### DIFF
--- a/sheetload/config.py
+++ b/sheetload/config.py
@@ -11,6 +11,7 @@ class ConfigLoader:
         self.sheet_config: dict = dict()
         self.sheet_column_rename_dict: dict = dict()
         self.sheet_columns: dict = dict()
+        self.excluded_columns: list = list()
         self.flags: FlagParser = flags
         self.yml_folder: str = yml_folder
         self.set_config()

--- a/sheetload/flags.py
+++ b/sheetload/flags.py
@@ -37,8 +37,8 @@ parser.add_argument(
 
 
 class FlagParser:
-    def __init__(self):
-        self.sheet_name = "df_renamer"
+    def __init__(self, test_sheet_name: str = str()):
+        self.sheet_name = test_sheet_name
         self.create_table = False
         self.sheet_key = parser.get_default("sheet_key")
         self.target_schema = parser.get_default("schema")

--- a/sheetload/sheetload.py
+++ b/sheetload/sheetload.py
@@ -53,6 +53,9 @@ class SheetBag:
         if not isinstance(df, pandas.DataFrame):
             raise TypeError("import_sheet did not return a pandas DataFrame")
         logger.debug(f"Loaded DF Cols: {df.columns.tolist()}")
+
+        # Perform exclusions, renamings and cleanups before releasing the sheet.
+        df = self.exclude_columns(df)
         df = self.rename_columns(df)
         df = self.run_cleanup(df)
         logger.debug(f"Cols should be: {df.columns}")
@@ -68,6 +71,23 @@ class SheetBag:
                         "should wrap it between double quotes."
                     )
             df = df.rename(columns=self.config.sheet_column_rename_dict)
+        return df
+
+    def exclude_columns(self, df) -> pandas.DataFrame:
+        """Drops columns referred to by their identifier (the exact string in the google sheet) when
+        a list is provided in the "excluded_columns" field of a sheet yml file.
+
+        Args:
+            df (pandas.DataFrame): DataFrame downloaded from google sheet.
+
+        Returns:
+            pandas.DataFrame: Either the same dataframe as originally provided or one with dropped
+            columns as required.
+        """
+
+        if self.config.sheet_config.get("excluded_columns", str()):
+            df = df.drop(self.config.sheet_config["excluded_columns"], axis=1)
+            return df
         return df
 
     @staticmethod

--- a/sheetload/yaml_schema.py
+++ b/sheetload/yaml_schema.py
@@ -25,6 +25,11 @@ validation_schema = {
                         },
                     },
                 },
+                "excluded_columns": {
+                    "anyof_type": ["list", "string"],
+                    "required": False,
+                    "schema": {"type": "string"},
+                },
             },
         },
     }

--- a/tests/mockers.py
+++ b/tests/mockers.py
@@ -1,7 +1,7 @@
 import pandas
 
 EXPECTED_CONFIG = {
-    "sheet_name": "df_renamer",
+    "sheet_name": "df_dropper",
     "sheet_key": "sample",
     "target_schema": "sand",
     "target_table": "bb_test_sheetload",
@@ -11,6 +11,7 @@ EXPECTED_CONFIG = {
         {"name": "col_one", "datatype": "varchar"},
         {"name": "renamed_col", "identifier": "long ass name", "datatype": "varchar"},
     ],
+    "excluded_columns": ["to_exclude"],
 }
 
 DIRTY_DF = {
@@ -35,7 +36,18 @@ RENAMED_DF = {
     "renamed_col": {0: "foo", 1: "bar", 2: "fizz"},
 }
 
+DROP_COL_DF = {
+    "col_a": [1, 2, 32],
+    "col b": ["as .    ", "b", "   c"],
+    "1. col_one": ["aa", "bb", "cc"],
+    "": ["q", "q", "q"],
+    "long ass name": ["foo", "bar", "fizz"],
+    "to_exclude": ["garbage1", "garbage2", "garbage3"],
+}
+
 RENAMED_COLS = ["col_a", "col b", "1. col_one", "", "renamed_col"]
+
+EXCLUDED_DF_COLS = ["col_a", "col b", "1. col_one", "", "long ass name"]
 
 
 def generate_test_df(df):

--- a/tests/sheets.yml
+++ b/tests/sheets.yml
@@ -26,3 +26,19 @@ sheets:
       - name: Renamed_col
         identifier: "long ass name"
         datatype: varchar
+
+  - sheet_name: df_dropper
+    sheet_key: sample
+    target_schema: sand
+    target_table: bb_test_sheetload
+    columns:
+      - name: col_a
+        datatype: int
+      - name: col_b
+        datatype: varchar
+      - name: col_one
+        datatype: varchar
+      - name: Renamed_col
+        identifier: "long ass name"
+        datatype: varchar
+    excluded_columns: ['to_exclude']

--- a/tests/test_configloader.py
+++ b/tests/test_configloader.py
@@ -13,7 +13,7 @@ FIXTURE_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)))
 def test_set_config(datafiles):
     from sheetload.config import ConfigLoader
 
-    flags = FlagParser()
+    flags = FlagParser(test_sheet_name="df_dropper")
     config = ConfigLoader(flags, yml_folder=str(datafiles))
 
     assert config.sheet_config == EXPECTED_CONFIG

--- a/tests/test_sheetloader.py
+++ b/tests/test_sheetloader.py
@@ -6,7 +6,14 @@ import pytest
 from sheetload.config import ConfigLoader
 from sheetload.flags import FlagParser
 
-from .mockers import DIRTY_DF, RENAMED_COLS, RENAMED_DF, generate_test_df
+from tests.mockers import (
+    DIRTY_DF,
+    DROP_COL_DF,
+    EXCLUDED_DF_COLS,
+    RENAMED_COLS,
+    RENAMED_DF,
+    generate_test_df,
+)
 
 FIXTURE_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)))
 
@@ -15,7 +22,7 @@ FIXTURE_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)))
 def test_rename_columns(datafiles):
     from sheetload.sheetload import SheetBag
 
-    flags = FlagParser()
+    flags = FlagParser(test_sheet_name="df_renamer")
     config = ConfigLoader(flags, yml_folder=str(datafiles))
     df = generate_test_df(DIRTY_DF)
     renamed_df = SheetBag(config, flags).rename_columns(df)
@@ -24,10 +31,22 @@ def test_rename_columns(datafiles):
 
 
 @pytest.mark.datafiles(FIXTURE_DIR)
+def test_exclude_columns(datafiles):
+    from sheetload.sheetload import SheetBag
+
+    flags = FlagParser(test_sheet_name="df_dropper")
+    config = ConfigLoader(flags, yml_folder=str(datafiles))
+    df = generate_test_df(DROP_COL_DF)
+    excluded_df = SheetBag(config, flags).exclude_columns(df)
+
+    assert excluded_df.columns.tolist() == EXCLUDED_DF_COLS
+
+
+@pytest.mark.datafiles(FIXTURE_DIR)
 def test_load_sheet(datafiles):
     from sheetload.sheetload import SheetBag
 
-    flags = FlagParser()
+    flags = FlagParser(test_sheet_name="df_renamer")
     config = ConfigLoader(flags, yml_folder=str(datafiles))
     with mock.patch.object(
         SheetBag, "_obtain_googlesheet", return_value=generate_test_df(DIRTY_DF)


### PR DESCRIPTION
## Description
Implements feature requested in #50. When providing a column string label of a list of column string labels **exactly** as formatted in the original google sheet, they will be dropped from the data frame obtained from the sheet using `pandas.DataFrame.drop(columns, axis=1)` method.

## How has this change been tested?
Unit test for column drop passes.

## Supporting doc, tickets, issues (Optional)
Closes #50 
