### PR TITLE
Fix: column dict should not be required

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,4 +1,4 @@
 cerberus
-data_tools @ git+ssh://git@github.com/tripactions/Data_Tooling.git@v2.1.7
+data_tools @ git+ssh://git@github.com/tripactions/Data_Tooling.git@v2.1.18
 pandas
-pyyaml
+pyyaml<5.2

--- a/sheetload/config.py
+++ b/sheetload/config.py
@@ -84,22 +84,21 @@ class ConfigLoader:
         """
 
         try:
-            if self.sheet_config:
-                if self.sheet_config.get("columns"):
-                    columns = self.sheet_config.get("columns")
-                    column_dict = dict()
-                    for column in columns:
-                        # FIXME: This is a temporary fix to make the data_tools function happy.
-                        # And will be removed in a future version as we will have conversion handled
-                        # natively.
-                        if column.get("datatype") == "numeric":
-                            data_type = "numeric(38,18)"
-                        else:
-                            data_type = column.get("datatype")
-                        column_dict.update(dict({column.get("name"): data_type}))
-                    if column_dict:
-                        logger.debug(column_dict)
-                        self.sheet_columns = column_dict
+            if self.sheet_config and self.sheet_config.get("columns"):
+                columns = self.sheet_config.get("columns")
+                column_dict = dict()
+                for column in columns:
+                    # FIXME: This is a temporary fix to make the data_tools function happy.
+                    # And will be removed in a future version as we will have conversion handled
+                    # natively.
+                    if column.get("datatype") == "numeric":
+                        data_type = "numeric(38,18)"
+                    else:
+                        data_type = column.get("datatype")
+                    column_dict.update(dict({column.get("name"): data_type}))
+                if column_dict:
+                    logger.debug(column_dict)
+                    self.sheet_columns = column_dict
         except KeyError as e:
             logger.warning(
                 f"No {str(e)} data for {self.flags.sheet_name}. But that might be intentional."

--- a/sheetload/config.py
+++ b/sheetload/config.py
@@ -70,9 +70,11 @@ class ConfigLoader:
                 )
             self.sheet_config = sheet_config[0]
             logger.debug(f"Sheet config dict: {self.sheet_config}")
-            self.sheet_config["columns"] = [
-                self.lowercase(column_dict) for column_dict in self.sheet_config["columns"]
-            ]
+            if self.sheet_config.get("columns"):
+                self.sheet_config["columns"] = [
+                    self.lowercase(column_dict) for column_dict in self.sheet_config.get("columns")
+                ]
+                logger.debug(f"Cols after casing: {self.sheet_config['columns']}")
         else:
             raise SheetloadConfigMissingError("No sheet name was provided, cannot fetch config.")
 
@@ -83,20 +85,21 @@ class ConfigLoader:
 
         try:
             if self.sheet_config:
-                columns = self.sheet_config["columns"]
-                column_dict = dict()
-                for column in columns:
-                    # FIXME: This is a temporary fix to make the data_tools function happy.
-                    # And will be removed in a future version as we will have conversion handled
-                    # natively.
-                    if column.get("datatype") == "numeric":
-                        data_type = "numeric(38,18)"
-                    else:
-                        data_type = column.get("datatype")
-                    column_dict.update(dict({column.get("name"): data_type}))
-                if column_dict:
-                    logger.debug(column_dict)
-                    self.sheet_columns = column_dict
+                if self.sheet_config.get("columns"):
+                    columns = self.sheet_config.get("columns")
+                    column_dict = dict()
+                    for column in columns:
+                        # FIXME: This is a temporary fix to make the data_tools function happy.
+                        # And will be removed in a future version as we will have conversion handled
+                        # natively.
+                        if column.get("datatype") == "numeric":
+                            data_type = "numeric(38,18)"
+                        else:
+                            data_type = column.get("datatype")
+                        column_dict.update(dict({column.get("name"): data_type}))
+                    if column_dict:
+                        logger.debug(column_dict)
+                        self.sheet_columns = column_dict
         except KeyError as e:
             logger.warning(
                 f"No {str(e)} data for {self.flags.sheet_name}. But that might be intentional."

--- a/tests/mockers.py
+++ b/tests/mockers.py
@@ -14,6 +14,13 @@ EXPECTED_CONFIG = {
     "excluded_columns": ["to_exclude"],
 }
 
+NO_COLS_EXPECTED_CONFIG = {
+    "sheet_name": "no_cols",
+    "sheet_key": "sample",
+    "target_schema": "sand",
+    "target_table": "bb_test_sheetload",
+}
+
 DIRTY_DF = {
     "col_a": [1, 2, 32],
     "col b": ["as .    ", "b", "   c"],

--- a/tests/sheets.yml
+++ b/tests/sheets.yml
@@ -26,6 +26,12 @@ sheets:
       - name: col2
         datatype: varchar
 
+  - sheet_name: test_sheet_3
+    sheet_key: 10J52dhgTRqtI_lm4bf9B02nQu4zu5u6r0h2VIDTjRXg
+    worksheet: Sheet2
+    target_schema: sand
+    target_table: bb_test_sheetload
+
   - sheet_name: df_renamer
     sheet_key: sample
     target_schema: sand
@@ -56,3 +62,8 @@ sheets:
         identifier: "long ass name"
         datatype: varchar
     excluded_columns: ['to_exclude']
+
+  - sheet_name: no_cols
+    sheet_key: sample
+    target_schema: sand
+    target_table: bb_test_sheetload

--- a/tests/test_configloader.py
+++ b/tests/test_configloader.py
@@ -4,7 +4,7 @@ import pytest
 
 from sheetload.flags import FlagParser
 
-from .mockers import EXPECTED_CONFIG
+from .mockers import EXPECTED_CONFIG, NO_COLS_EXPECTED_CONFIG
 
 FIXTURE_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)))
 
@@ -17,3 +17,13 @@ def test_set_config(datafiles):
     config = ConfigLoader(flags, yml_folder=str(datafiles))
 
     assert config.sheet_config == EXPECTED_CONFIG
+
+
+@pytest.mark.datafiles(FIXTURE_DIR)
+def test_set_config(datafiles):
+    from sheetload.config import ConfigLoader
+
+    flags = FlagParser(test_sheet_name="no_cols")
+    config = ConfigLoader(flags, yml_folder=str(datafiles))
+
+    assert config.sheet_config == NO_COLS_EXPECTED_CONFIG


### PR DESCRIPTION
## Description
While columns dict should not be required by design, the implementation in the code make it so. 

Code was refactored to read column dict via `dict.get('key')` instead of `dict['key']`. 

## How has this change been tested?
Tested on a real test sheet and added a test case for this as well. All passing.

## Supporting doc, tickets, issues (Optional)
Closes #88 
