### PR TITLE
Fix: Provide a default to SheetBag local copy of target schema

### DIFF
--- a/sheetload/sheetload.py
+++ b/sheetload/sheetload.py
@@ -18,7 +18,7 @@ class SheetBag:
         self.sheet_df: pandas.DataFrame = pandas.DataFrame()
         self.flags: FlagParser = flags
         self.config: ConfigLoader = config
-        self.target_schema: str = str()
+        self.target_schema: str = self.config.target_schema
         self.consume_config()
 
     def consume_config(self):


### PR DESCRIPTION
## Description
Somehow the prod/dev target schema override was broken when in prod. I belive this happened when I was implementing mypy type hints.