### PR TITLE
Feature: Remove data tools dependency

### DIFF
--- a/core/sheetload.py
+++ b/core/sheetload.py
@@ -194,7 +194,7 @@ class SheetBag:
     def run(self):
         self.load_sheet()
         if not self.flags.dry_run:
-            self.push_sheet_adaptor()
-            self.check_table_adaptor()
+            self.push_sheet()
+            self.check_table()
         else:
             logger.info("Nothing pushed since you were in --dry_run mode.")

--- a/core/sheetload.py
+++ b/core/sheetload.py
@@ -3,15 +3,13 @@ import sys
 from typing import TYPE_CHECKING, Tuple
 
 import pandas
-from data_tools.db import odbc
-from data_tools.db.pandas import push_pandas_to_snowflake
 
+from core.adapters.connection import Connection, Credentials
+from core.adapters.impl import SnowflakeAdapter
 from core.cleaner import SheetCleaner
 from core.clients.google import GoogleSpreadsheet
 from core.config.config import ConfigLoader
 from core.config.profile import Profile
-from core.adapters.connection import Credentials, Connection
-from core.adapters.impl import SnowflakeAdapter
 from core.exceptions import ColumnNotFoundInDataFrame, TableDoesNotExist
 from core.logger import GLOBAL_LOGGER as logger
 

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -3,3 +3,5 @@ pandas
 pyyaml
 snowflake-sqlalchemy
 sqlalchemy
+gspread
+oauth2client

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,5 +1,4 @@
 cerberus
-data_tools @ git+ssh://git@github.com/tripactions/Data_Tooling.git@v2.1.7
 pandas
 pyyaml
 snowflake-sqlalchemy


### PR DESCRIPTION
## Description
Following the last rounds of refactoring, we do not need to use any of the `data_tools` functionality.
- Imports of `data_tools` modules were removed
- Additional pip requirements were added (they were previously installed by `data_tools`)
- Nasty bug was fixed in the calls to push and check tables in `SheetBag`

## How has this change been tested?
All unit tests passing, test against Snowflake and from a real google sheet completed with success.

## Supporting doc, tickets, issues
Closes #99 