### PR TITLE
Fix: snowflake connector issue

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,19 @@
 repos:
   - repo: https://github.com/ambv/black
-    rev: stable
+    rev: 19.10b0
     hooks:
     - id: black
       language_version: python3
-      args: [--line-length=100]
+      args: [--line-length=100, --target-version=py37]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.4.0
+    hooks:
+    - id: end-of-file-fixer
+    - id: trailing-whitespace
+  - repo: git://github.com/luismayta/pre-commit-mypy
+    rev: "aad0a7b"
+    hooks:
+    - id: mypy
+      exclude_types: [python]
+      always_run: true
+      args: [--ignore-missing-imports, "core"]

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,7 +1,7 @@
 cerberus==1.3.2
 pandas==0.25.3
 pyyaml==5.3
-snowflake-connector-python\<2.0.0
+snowflake-connector-python<2.0.0
 snowflake-sqlalchemy==1.1.18
 sqlalchemy==1.3.13
 gspread==3.1.0

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,6 +1,7 @@
 cerberus==1.3.2
 pandas==0.25.3
 pyyaml==5.3
+snowflake-connector-python\<2.0.0
 snowflake-sqlalchemy==1.1.18
 sqlalchemy==1.3.13
 gspread==3.1.0

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,7 +1,7 @@
 cerberus==1.3.2
 pandas==0.25.3
 pyyaml==5.3
-snowflake-connector-python<2.0.0
+snowflake-connector-python<2.1.3
 snowflake-sqlalchemy==1.1.18
 sqlalchemy==1.3.13
 gspread==3.1.0


### PR DESCRIPTION
## Description
CI was failing probably due to one of the pip requirements leaving `snowflake-connector-python` open. 


## How has this change been tested?


## Supporting doc, tickets, issues (Optional)
The internet says pinning to `<2.0.0` might work (https://stackoverflow.com/questions/59982458/importerror-cannot-import-name-py2)