### PR TITLE
Fix: sub command help formatting

### DIFF
--- a/core/main.py
+++ b/core/main.py
@@ -9,7 +9,7 @@ from core.flags import FlagParser
 from core.logger import log_manager
 
 parser = argparse.ArgumentParser(
-    prog="sheetload: a handy tool to load google sheets into your DB.",
+    prog="sheetload",
     formatter_class=argparse.RawTextHelpFormatter,
     description="CLI tool to load google sheets onto a DB.",
     epilog="Select one of these sub-commands to find specific help for those.",


### PR DESCRIPTION
## Description
Subcommands in `sheetload upload --help` header were badly displayed due to a bad configuration of the `prog=` argument in argparse.

## Supporting doc, tickets, issues
Closes #77 
