### PR TITLE
Fix: Implement generic col checked and call it in exclude cols

### DIFF
--- a/tests/sheets.yml
+++ b/tests/sheets.yml
@@ -18,7 +18,7 @@ sheets:
         datatype: date
       - name: camel_cased_col
         datatype: int
-    excluded_columns: 'to_exclude'
+    excluded_columns: ['to_exclude', 'col_not_in_df_for_fun']
 
   - sheet_name: test_sheet_2
     sheet_key: 10J52dhgTRqtI_lm4bf9B02nQu4zu5u6r0h2VIDTjRXg

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,3 +16,15 @@ def test_cast_pandas_dtypes():
     expected_cast = generate_test_df(CAST_DF)
 
     assert cast_df.to_dict() == expected_cast.to_dict()
+
+
+def test_check_columns_in_df():
+    from core.utils import check_columns_in_df
+
+    cols = ["column_that_is_not_in_df", "col_int"]
+
+    to_check = generate_test_df(TO_CAST_DF)
+    is_subset, columns = check_columns_in_df(to_check, cols, suppress_warning=True)
+
+    assert is_subset is False
+    assert columns == [cols[1]]


### PR DESCRIPTION
## Description
As identified in #145 `core.sheetload.SheetBag.exclude_columns()` would cause `pandas` to raise a `KeyError` if a column up for dropping was not present in the dataframe as no check of any kind was placed in that method 🤦 .

- Implements a generic column in df checker (since this is something other methods should be able to do --refactor will be needed to prefer this newly implemented method over adhoc ones as raised in #149 )

- Calls the new method from `core.utils` to check columns and throw appropriate warnings on `exclude_columns()`.

## How has this change been tested?
- unit test `test_check_columns_in_df()` in place and passing on local tests.
- tested on a real sheet and expected behaviour happened.

## Supporting doc, tickets, issues (Optional)
Closes #145 

