### PR TITLE
Feature: Raise error when about to import dupe columns

### DIFF
--- a/core/clients/google.py
+++ b/core/clients/google.py
@@ -1,4 +1,3 @@
-import collections
 from pathlib import Path
 
 import gspread
@@ -8,13 +7,13 @@ from oauth2client.service_account import ServiceAccountCredentials
 
 from core.config.profile import Profile
 from core.exceptions import (
-    DuplicatedColumnsInSheet,
     GoogleCredentialsFileMissingError,
     GoogleSpreadSheetNotFound,
     NoWorkbookLoadedError,
     WorksheetNotFoundError,
 )
 from core.logger import GLOBAL_LOGGER as logger
+from core.utils import check_dupe_cols
 
 SCOPE = ["https://spreadsheets.google.com/feeds", "https://www.googleapis.com/auth/drive"]
 
@@ -77,7 +76,7 @@ class GoogleSpreadsheet:
             logger.info("Sheet loaded successfully")
             if grab_header:
                 values = worksheet.get_all_values()
-                self._check_dupe_cols(values[0])
+                check_dupe_cols(values[0])
                 df = pandas.DataFrame(values[1:], columns=values[0])
             else:
                 df = pandas.DataFrame(worksheet.get_all_values())
@@ -86,14 +85,4 @@ class GoogleSpreadsheet:
             raise WorksheetNotFoundError(
                 f"Could not find {worksheet_name} in workbook. "
                 "If 'default sheet' not found all sheets in the workbook may be empty."
-            )
-
-    @staticmethod
-    def _check_dupe_cols(columns: list) -> None:
-        """checks dupes in a list
-        """
-        dupes = [item for item, count in collections.Counter(columns).items() if count > 1]
-        if dupes:
-            raise DuplicatedColumnsInSheet(
-                f"Duplicate column names found in Google Sheet: {dupes}. Aborting. Fix your sheet."
             )

--- a/core/exceptions.py
+++ b/core/exceptions.py
@@ -60,3 +60,7 @@ class DatabaseError(Exception):
 
 class TableDoesNotExist(Exception):
     "When query for rows and cols came back empty or none"
+
+
+class DuplicatedColumnsInSheet(Exception):
+    "when a google sheet contains the same column name twice"

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,6 +1,6 @@
 import collections
 from pathlib import Path
-from typing import Tuple, Union, Optional
+from typing import Optional, Tuple, Union
 
 import pandas
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,9 +1,15 @@
+import collections
 from pathlib import Path
-from typing import Tuple, Union
+from typing import Tuple, Union, Optional
 
 import pandas
 
-from core.exceptions import ColumnNotFoundInDataFrame, NearestFileNotFound, UnsupportedDataTypeError
+from core.exceptions import (
+    ColumnNotFoundInDataFrame,
+    DuplicatedColumnsInSheet,
+    NearestFileNotFound,
+    UnsupportedDataTypeError,
+)
 from core.logger import GLOBAL_LOGGER as logger
 
 
@@ -115,3 +121,14 @@ def check_columns_in_df(
             f"{cols_not_in_df} not in DataFrame. Check spelling or clean up your sheets.yml"
         )
     return False, reduced_cols
+
+
+def check_dupe_cols(columns: list, suppress_warning: bool = False) -> Optional[list]:
+    """checks dupes in a list
+    """
+    dupes = [item for item, count in collections.Counter(columns).items() if count > 1]
+    if dupes and not suppress_warning:
+        raise DuplicatedColumnsInSheet(
+            f"Duplicate column names found in Google Sheet: {dupes}. Aborting. Fix your sheet."
+        )
+    return dupes

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,3 +28,12 @@ def test_check_columns_in_df():
 
     assert is_subset is False
     assert columns == [cols[1]]
+
+
+def test_check_dupe_cols():
+    from core.utils import check_dupe_cols
+
+    list_with_dupe = ["a", "a", "b"]
+    dupes = check_dupe_cols(list_with_dupe, suppress_warning=True)
+
+    assert dupes == ["a"]


### PR DESCRIPTION
## Description
As raised in #123 when duplicate columns are present in the sheet that is about to be imported no warning or test checks. This leads pandas to handle the duplication of the columns by adding a suffix. Since this is mostly hidden it will create confusions in user space if a column was to be submitted for renaming, casting or exclusion.

- duplicate column names in google sheet header will now raise a `DuplicatedColumnsInSheet` error and abort the job.

## How has this change been tested?
- tested with a real google sheet
- unit test on dupe checker passing in local tests.

## Supporting doc, tickets, issues (Optional)
Closes #123 
