### PR TITLE
Feature: Handle dev schema fallback in profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,39 +16,40 @@ Loads Google sheets from Data Team shared drive and uploads them to Snowflake.
 Performs some cleanups on column names and string (such as removing trailing spaces etc.)
 
 ## Installation
+
 1. Activate the virtual environment you might want to use it in (most likely it's going to be the one you set up for `data_etl`.
 2. Make sure `pip` is above `v19.1` otherwise one of the required packages by `sheetload` (`data_tools`) will not be installed correctly. If you're not sure you can check by doing `pip --version`. If you're behind, you can upgrade it via `pip install -U pip`.
 3. Make sure your access tokens and usernames are installed according to TripActions Data Tooling standards. Setup information can be found in [data_tools Credentials](https://github.com/tripactions/data_tooling/blob/master/README.md#credentials).
+
 4. Install Sheetload
+
 ```bash
 pip install git+ssh://git@github.com/bastienboutonnet/sheetload.git@v0.2.1a0
 ```
+
 Make sure you've setup your GitHub ssh keys, if you don't know how to do it, check [here](https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account/).
 
 5. Check your installation:
+
 ```bash
 sheetload --version
 ```
+
 Should display something like this:
+
 ```bash
 ➜ sheetload --version
 sheetload 0.2.1a0
 ```
 
-## Usage
-Using `sheeload` is simple. You call it, and provide the following info via the command line:
-- a google sheet key
-- a target schema
-- a target table
-For example:
-```bash
-sheetload --sheet_key adkajhsdkajhkajh8768271872613akjsdhaksjd --schema sand --table test_table
-```
 This mode will load the content of the sheet into a pandas dataframe, perform default basic [cleanups](#cleanups), and push the dataframe to a Snowflake table. No data type casting is possible in this mode.
 
 ## Cleanups
+
 ### Column Names
+
 To avoid issues with Snowflake column formatting, column names that:
+
 - contain spaces
 - `/`
 - camelCasing
@@ -57,26 +58,33 @@ will be cleaned to snake case.
 For example: `col a` -> `col_a`, `company/account` -> `company_account`
 
 ### String Trimming
+
 Another common issue often found in google sheet are trailing/leading whitespace. This kind of whitespace will be removed. This can cause issues down the line if you have to match strings or perform equality tests between two strings (although it is always safer when doing so to make sure to clean your strings beforehand --but that's beyond the scope of this explanation).
 
-
-
 ## Usage
+
 There are two ways of using `sheeload`:
 
 ### CLI Only
+
 This is the simplest and quickes useage mode. All you need is to call `sheetload` with:
+
 - a googlesheet key
 - a target schema
 - a target table
+
 ```bash
 sheetload --sheet_key adkajhsdkajhkajh8768271872613akjsdhaksjd --schema sand --table test_table
 ```
+
 This mode will load the content of the sheet into a pandas dataframe, perform default basic cleanups (INSERT DOC LINK LATER), and push the dataframe to a Snowflake table. No data type casting is possible in this mode.
 
 ### CLI + Config
+
 This is a more involved mode, but great to put in place when you've tested things or if you know you will have to cast datatypes.
+
 - Create a `sheets.yml` file in the path of your choosing. This config file should look like so:
+
 ```yaml
 sheets:
   - sheet_name: test_sheet
@@ -94,16 +102,21 @@ sheets:
 
 Sheets are referred to by a human readable name (`sheet_name`). This is the name you will need to use later when calling `sheetload`.
 The rest of the information is pretty straighforward. Column datatype casting is achived by adding a `columns` entry listing all the columns for which a specific datatype must be cast see [Important notes section below](#Important-notes-on-`Sheets.yml`-formatting) for info on column name formatting.
+
 - Navigate to the folder containing your `sheets.yml` file:
+
 ```bash
 cd /path/to/your/yml/folder
 ```
+
 - Call `sheetload`🧼 providing only a sheet name `--sheet_name` in this example it would be `test_sheet`. So it all should look like this
+
 ```bash
 sheetload --sheet_name test_sheet
 ```
 
 #### Important Notes on `Sheets.yml` formatting
+
 - **Do you need to list ALL the columns in your sheet?**
 No! You don't have to. You can leave the columns part empty and **you only need to add a column if you want to override its format when it's saved to Snowflake**
 - **Do the column names need to be in the format of the original sheet?**
@@ -112,7 +125,8 @@ No. **Actually they shouldn't!** As mentioned [earlier in the documentation](#co
 Yeah that's kinda expected. Besides checking [the cleanup steps documentation above](#column-names) you should add the `--dry_run` flag to see what would happen to your sheet. This mode will not write to Snowflake, and will display handy information about the look of your data frame:
 
 It first gives you a list of all the columns in the table **formatted for Snowflake** as well as the data type of each of the columns so that you can spot whether you might have to override any of them when writing to Snowflake. **IMPORTANT**: These are *Pandas datatypes*. It will look like this:
-```
+
+```pandas
 2019-11-16 12:59:15 - data_tools.logging - [INFO] - POST-CLEANING PREVIEW: This is what you would push to the database:
 
 DataFrame DataTypes:
@@ -123,7 +137,8 @@ dtype: object
 ```
 
 Then it will also show you a preview of the dataframe (first few rows). **NOTE: For dataframes with many columns the preview will likely be trucated** (this issue will be addressed in an upcoming release [see issue #39](https://github.com/bastienboutonnet/sheetload/issues/39)). The preview will look like this:
-```
+
+```pandas
 DataFrame Preview:
 
   col_a col_b
@@ -133,6 +148,7 @@ DataFrame Preview:
 ```
 
 ### Useful flags
+
 These flags are valid for both of the execution modes [outlined above](#usage).
 
 **Dry Run**: Dry runs (skipping pushing to the database) can be achieved by adding the `--dry_run` flag.
@@ -141,39 +157,3 @@ These flags are valid for both of the execution modes [outlined above](#usage).
 Down the line we expect this mode to have more functionality
 
 **Create Table**: The target table may not be present on the database. You can create it by adding the `--create_table` flag.
-
-### Other Flags 🤯
-There are a few more flags linked to modes, log level and forcing intented protection measures down. Here is the full list of flags with their use, defaults etc. (You can get that by doing `sheetload -h`)
-```
-usage: sheetload: a handy tool to load google sheets into your DB.
-       [-h] [--version] {upload} ...
-
-CLI tool to load google sheets onto a DB.
-
-optional arguments:
-  -h, --help  show this help message and exit
-  --version   show program's version number and exit
-
-Available sub commands:
-  {upload}
-    upload    Pull, sanitize and upload a google sheet.
-
-    Optional arguments:
-      -sn SHEET_NAME, --sheet_name SHEET_NAME
-                        Name of your sheet from config
-      -sk SHEET_KEY, --sheet_key SHEET_KEY
-                            Google sheet Key
-      --log_level LOG_LEVEL
-                            sets the log level
-      -f, --force           Forces target schema to be followed. Even when in DEV
-                            mode.
-      --dry_run             Skips pushing to database
-      -i, --interactive     Turns on interactive mode, which allows previews and
-                            cleanup choices
-      --schema SCHEMA       Target Schema Name
-      --table TABLE         Target Table Name
-      --create_table        Creates target table before pushing.
-```
-
-
-

--- a/core/exceptions.py
+++ b/core/exceptions.py
@@ -72,3 +72,7 @@ class TableDoesNotExist(SheetLoadError):
 
 class DuplicatedColumnsInSheet(SheetLoadError):
     "when a google sheet contains the same column name twice"
+
+
+class TargetSchemaMissing(SheetLoadError):
+    "when no target schema whatsoever can be found"

--- a/core/flags.py
+++ b/core/flags.py
@@ -23,9 +23,7 @@ class FlagParser:
         self.sheet_key = str()
         self.target_schema = str()
         self.target_table = str()
-        self.mode = "dev"
         self.log_level = str()
-        self.force = False
         self.interactive = False
         self.dry_run = False
         self.parser = parser
@@ -41,9 +39,7 @@ class FlagParser:
         self.sheet_key = self.args.sheet_key
         self.target_schema = self.args.schema
         self.target_table = self.args.table
-        self.mode = self.args.mode
         self.log_level = self.args.log_level
-        self.force = self.args.force
         self.interactive = self.args.interactive
         self.dry_run = self.args.dry_run
         self.sheet_config_dir = self.args.sheet_config_dir

--- a/core/main.py
+++ b/core/main.py
@@ -18,20 +18,10 @@ parser.add_argument("--version", action="version", version=f"%(prog)s Running v{
 
 base_subparser = argparse.ArgumentParser(add_help=False)
 base_subparser.add_argument(
-    "--mode", help="Chooses between prod or dev run", type=str, default="dev"
-)
-base_subparser.add_argument(
     "-sn", "--sheet_name", help="Name of your sheet from config", type=str, default=None
 )
 base_subparser.add_argument("-sk", "--sheet_key", help="Google sheet Key", type=str, default=None)
 base_subparser.add_argument("--log_level", help="sets the log level", type=str, default=str())
-base_subparser.add_argument(
-    "-f",
-    "--force",
-    help="Forces target schema to be followed. Even when in DEV mode.",
-    action="store_true",
-    default=False,
-)
 base_subparser.add_argument(
     "--dry_run", help="Skips pushing to database", action="store_true", default=False
 )

--- a/core/yaml/yaml_schema.py
+++ b/core/yaml/yaml_schema.py
@@ -8,7 +8,7 @@ config_schema = {
                 "sheet_name": {"required": True, "type": "string"},
                 "sheet_key": {"required": True, "type": "string"},
                 "worksheet": {"required": False, "type": "string"},
-                "target_schema": {"required": True, "type": "string"},
+                "target_schema": {"required": False, "type": "string"},
                 "target_table": {"required": True, "type": "string"},
                 "snake_case_camel": {"required": False, "type": "boolean"},
                 "columns": {

--- a/tests/sheets.yml
+++ b/tests/sheets.yml
@@ -81,3 +81,7 @@ sheets:
     columns:
       - name: CamelCasedCol
         datatype: int
+
+  - sheet_name: sheet_with_no_schema
+    sheet_key: sample
+    target_table: sample

--- a/tests/test_configloader.py
+++ b/tests/test_configloader.py
@@ -36,3 +36,21 @@ def test_set_config(datafiles):
 
     assert config.sheet_config == EXPECTED_CONFIG
     assert config2.sheet_config == NO_COLS_EXPECTED_CONFIG
+
+
+@pytest.mark.datafiles(FIXTURE_DIR)
+def test__override_cli_args(datafiles):
+    from core.config.config import ConfigLoader
+
+    from core.config.project import Project
+    from core.main import parser
+
+    flags = FlagParser(
+        parser,
+        test_sheet_name="sheet_with_no_schema",
+        project_dir=str(datafiles),
+        sheet_config_dir=str(datafiles),
+    )
+    project = Project(flags)
+    config = ConfigLoader(flags, project)
+    assert config.target_schema == project.target_schema


### PR DESCRIPTION
## Description
- target schema parsing from config and project hierachy was actually broken
- now `flags` has prio, then sheet `Config`, then `Project` if this fails `sheetload` errors
- `dev` mode is deprecated for now as I come up with a better solution to handle this.


## How has this change been tested?
- tested with several parameters 
- unitest on the `override_cli_args()` which takes care of comparing the project's default `target_schema` after config was consumed.

## Supporting doc, tickets, issues
Closes #153 
